### PR TITLE
Add Express server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # codex-online
+
+This project provides a simple Express server with basic CRUD endpoints for a `Customer` resource. Data is stored in memory for simplicity.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+   (An internet connection is required.)
+2. Start the server:
+   ```bash
+   npm start
+   ```
+
+The server listens on port `3000` by default or the port defined in the `PORT` environment variable.
+
+## Endpoints
+
+- `GET /customers` – list all customers.
+- `POST /customers` – create a customer (JSON body).
+- `GET /customers/:id` – get a customer by id.
+- `PUT /customers/:id` – update a customer (JSON body).
+- `DELETE /customers/:id` – delete a customer.
+
+Customer data is not persisted across restarts since it is stored in memory.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "codex-online",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,55 @@
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(express.json());
+
+let nextId = 1;
+const customers = new Map();
+
+// List all customers
+app.get('/customers', (req, res) => {
+  res.json(Array.from(customers.values()));
+});
+
+// Create a new customer
+app.post('/customers', (req, res) => {
+  const customer = { id: nextId++, ...req.body };
+  customers.set(customer.id, customer);
+  res.status(201).json(customer);
+});
+
+// Read a customer by id
+app.get('/customers/:id', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  const customer = customers.get(id);
+  if (!customer) {
+    return res.status(404).json({ error: 'Customer not found' });
+  }
+  res.json(customer);
+});
+
+// Update a customer
+app.put('/customers/:id', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  if (!customers.has(id)) {
+    return res.status(404).json({ error: 'Customer not found' });
+  }
+  const updated = { ...customers.get(id), ...req.body, id };
+  customers.set(id, updated);
+  res.json(updated);
+});
+
+// Delete a customer
+app.delete('/customers/:id', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  if (!customers.has(id)) {
+    return res.status(404).json({ error: 'Customer not found' });
+  }
+  customers.delete(id);
+  res.status(204).send();
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- initialize Node project and set up package.json
- implement an Express server with CRUD routes for an in-memory customers list
- document setup and endpoints in README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node server.js` *(fails: Cannot find module 'express')*
- `npm install express sqlite3` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685c94193c7083219387a081e125e6ed